### PR TITLE
Endre source for hierarki-snapshot

### DIFF
--- a/dbt/snapshots/_source.yml
+++ b/dbt/snapshots/_source.yml
@@ -7,5 +7,6 @@ sources:
     tables:
       - name: xxrtv_gl_segment_v
       - name: xxrtv_gl_hierarki_v
-      - name: xxrtv_gl_hierarki_v__v1
+        identifier: xxrtv_gl_hierarki_v__v1
+      #- name: xxrtv_gl_hierarki_v__v1
       - name: xxrtv_gl_period_status_v


### PR DESCRIPTION
Snapshot for hierarkier skal hentes fra tlost og ikke utdaterte tabeller.